### PR TITLE
Correctly recognise "Syntax OK" message from dead_end

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,8 +19,10 @@ function activate(context) {
           deadEndOutput = stderr;
         }
 
+        const syntaxOkOutputRegex = /Syntax OK\s*/;
         console.log(deadEndOutput);
-        if (deadEndOutput == "Syntax OK") return;
+
+        if (syntaxOkOutputRegex.test(deadEndOutput)) return;
 
         const lineRegex = /❯\s+(\d+)(.*)/g;
         const allLines = [];


### PR DESCRIPTION
Current latest dead_end (v4.0.0) appends a newline to the "Syntax OK"
message. Presumably this was not the case with older versions which is
why this extension was not expecting the newline. This change updates
this extension to not care about the newline.

Prior to this change the extension would throw an error when syntax was OK because it was attempting to parse line numbers from the output.